### PR TITLE
Add NFT minting endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.3
 require (
 	github.com/go-playground/validator/v10 v10.15.1
 	github.com/gofiber/fiber/v2 v2.52.9
+	github.com/google/uuid v1.6.0
 )
 
 require (
@@ -12,7 +13,6 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/internal/http/nft/handler.go
+++ b/internal/http/nft/handler.go
@@ -1,0 +1,60 @@
+package nft
+
+import (
+	"github.com/dorsium/dorsium-rpc-gateway/internal/service/nft"
+	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
+	"github.com/go-playground/validator/v10"
+	"github.com/gofiber/fiber/v2"
+)
+
+// Handler provides NFT HTTP handlers.
+type Handler struct {
+	service  nft.Service
+	validate *validator.Validate
+}
+
+// NewHandler creates an NFT handler.
+func NewHandler(svc nft.Service) *Handler {
+	return &Handler{service: svc, validate: validator.New()}
+}
+
+// RegisterRoutes registers NFT routes.
+func (h *Handler) RegisterRoutes(r fiber.Router) {
+	r.Get("/:id", h.getMetadata)
+	r.Post("/mint", h.mint)
+	r.Get("/:id/image", h.getImage)
+}
+
+func (h *Handler) getMetadata(c *fiber.Ctx) error {
+	id := c.Params("id")
+	meta, err := h.service.GetMetadata(id)
+	if err != nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "not found"})
+	}
+	return c.JSON(meta)
+}
+
+func (h *Handler) mint(c *fiber.Ctx) error {
+	var req model.MintRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid payload"})
+	}
+	if err := h.validate.Struct(req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "validation failed"})
+	}
+	meta, err := h.service.MintNFT(req)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+	return c.Status(fiber.StatusCreated).JSON(meta)
+}
+
+func (h *Handler) getImage(c *fiber.Ctx) error {
+	id := c.Params("id")
+	data, ct, err := h.service.GetImage(id)
+	if err != nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "not found"})
+	}
+	c.Set("Content-Type", ct)
+	return c.Send(data)
+}

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -3,10 +3,13 @@ package http
 import (
 	"github.com/dorsium/dorsium-rpc-gateway/internal/config"
 	mininghttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/mining"
+	nfthttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/nft"
 	wallethttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/wallet"
+	nftrepo "github.com/dorsium/dorsium-rpc-gateway/internal/repository/nft"
 	walletrepo "github.com/dorsium/dorsium-rpc-gateway/internal/repository/wallet"
 	"github.com/dorsium/dorsium-rpc-gateway/internal/service"
 	miningservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/mining"
+	nftservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/nft"
 	walletservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/wallet"
 	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
 	"github.com/gofiber/fiber/v2"
@@ -36,6 +39,13 @@ func (s *Server) RegisterRoutes() {
 	handler := wallethttp.NewHandler(svc)
 	walletGroup := api.Group("/wallet")
 	handler.RegisterRoutes(walletGroup)
+
+	// nft routes
+	nRepo := nftrepo.New()
+	nSvc := nftservice.New(nRepo, nftservice.NewDummyMintHandler())
+	nHandler := nfthttp.NewHandler(nSvc)
+	nftGroup := api.Group("/nft")
+	nHandler.RegisterRoutes(nftGroup)
 
 	// mining routes
 	mVerifier := miningservice.NewDummyVerifier()

--- a/internal/repository/nft/nft.go
+++ b/internal/repository/nft/nft.go
@@ -1,0 +1,38 @@
+package nft
+
+import (
+	"errors"
+
+	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
+)
+
+// Repository abstracts NFT data source.
+type Repository interface {
+	Save(model.NFTMetadata) error
+	GetByID(string) (*model.NFTMetadata, error)
+}
+
+type repo struct {
+	store map[string]model.NFTMetadata
+}
+
+// ErrNotFound is returned when an NFT is missing.
+var ErrNotFound = errors.New("nft not found")
+
+// New returns an in-memory NFT repository implementation.
+func New() Repository {
+	return &repo{store: make(map[string]model.NFTMetadata)}
+}
+
+func (r *repo) Save(n model.NFTMetadata) error {
+	r.store[n.ID] = n
+	return nil
+}
+
+func (r *repo) GetByID(id string) (*model.NFTMetadata, error) {
+	n, ok := r.store[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return &n, nil
+}

--- a/internal/service/nft/nft.go
+++ b/internal/service/nft/nft.go
@@ -1,0 +1,86 @@
+package nft
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
+	"github.com/google/uuid"
+)
+
+// MintHandler executes NFT minting.
+type MintHandler interface {
+	Mint(model.NFTMetadata) error
+}
+
+// Repository defines persistence layer methods.
+type Repository interface {
+	Save(model.NFTMetadata) error
+	GetByID(string) (*model.NFTMetadata, error)
+}
+
+// Service exposes NFT operations.
+type Service interface {
+	GetMetadata(id string) (*model.NFTMetadata, error)
+	MintNFT(model.MintRequest) (*model.NFTMetadata, error)
+	GetImage(id string) ([]byte, string, error)
+}
+
+type service struct {
+	repo        Repository
+	mintHandler MintHandler
+}
+
+// New creates an NFT service.
+func New(repo Repository, mh MintHandler) Service {
+	return &service{repo: repo, mintHandler: mh}
+}
+
+func (s *service) GetMetadata(id string) (*model.NFTMetadata, error) {
+	return s.repo.GetByID(id)
+}
+
+func (s *service) MintNFT(req model.MintRequest) (*model.NFTMetadata, error) {
+	nft := model.NFTMetadata{
+		ID:         uuid.New().String(),
+		Name:       req.Name,
+		ImageURL:   req.ImageURL,
+		Attributes: req.Attributes,
+	}
+	if err := s.mintHandler.Mint(nft); err != nil {
+		return nil, err
+	}
+	if err := s.repo.Save(nft); err != nil {
+		return nil, err
+	}
+	return &nft, nil
+}
+
+func (s *service) GetImage(id string) ([]byte, string, error) {
+	nft, err := s.repo.GetByID(id)
+	if err != nil {
+		return nil, "", err
+	}
+	resp, err := http.Get(nft.ImageURL)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", err
+	}
+	ct := resp.Header.Get("Content-Type")
+	if ct == "" {
+		ct = http.DetectContentType(data)
+	}
+	return data, ct, nil
+}
+
+// dummyMintHandler is a placeholder MintHandler.
+type dummyMintHandler struct{}
+
+// NewDummyMintHandler creates a no-op MintHandler.
+func NewDummyMintHandler() MintHandler { return dummyMintHandler{} }
+
+func (dummyMintHandler) Mint(model.NFTMetadata) error { return nil }

--- a/pkg/model/nft.go
+++ b/pkg/model/nft.go
@@ -1,0 +1,16 @@
+package model
+
+// NFTMetadata describes token metadata.
+type NFTMetadata struct {
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	ImageURL   string            `json:"imageUrl"`
+	Attributes map[string]string `json:"attributes,omitempty"`
+}
+
+// MintRequest represents payload for minting an NFT.
+type MintRequest struct {
+	Name       string            `json:"name" validate:"required"`
+	ImageURL   string            `json:"imageUrl" validate:"required,url"`
+	Attributes map[string]string `json:"attributes"`
+}


### PR DESCRIPTION
## Summary
- add NFT model definitions
- implement in-memory NFT repository
- create NFT service with dummy MintHandler
- expose new HTTP handlers and routes

## Testing
- `go mod tidy`
- `go build ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68841055e40083239a3655222b541bbb