### PR TITLE
Add node management endpoints

### DIFF
--- a/internal/http/node/handler.go
+++ b/internal/http/node/handler.go
@@ -1,0 +1,77 @@
+package node
+
+import (
+	"strconv"
+
+	nodesvc "github.com/dorsium/dorsium-rpc-gateway/internal/service/node"
+	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
+	"github.com/gofiber/fiber/v2"
+)
+
+// Handler provides node HTTP handlers.
+type Handler struct {
+	service nodesvc.Service
+}
+
+// NewHandler creates a node handler.
+func NewHandler(svc nodesvc.Service) *Handler { return &Handler{service: svc} }
+
+// RegisterRoutes registers node routes.
+func (h *Handler) RegisterRoutes(r fiber.Router) {
+	r.Get("/list", h.list)
+	r.Get("/:id/status", h.status)
+	r.Post("/ping", h.ping)
+	r.Get("/:id/profile", h.profile)
+	r.Get("/:id/metrics", h.metrics)
+}
+
+func (h *Handler) status(c *fiber.Ctx) error {
+	id := c.Params("id")
+	st, err := h.service.GetStatus(id)
+	if err != nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "not found"})
+	}
+	return c.JSON(st)
+}
+
+func (h *Handler) ping(c *fiber.Ctx) error {
+	var p model.NodePing
+	if err := c.BodyParser(&p); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid payload"})
+	}
+	if p.ID == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "id required"})
+	}
+	if err := h.service.Ping(p); err != nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "not found"})
+	}
+	return c.JSON(fiber.Map{"success": true})
+}
+
+func (h *Handler) profile(c *fiber.Ctx) error {
+	id := c.Params("id")
+	prof, err := h.service.GetProfile(id)
+	if err != nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "not found"})
+	}
+	return c.JSON(prof)
+}
+
+func (h *Handler) metrics(c *fiber.Ctx) error {
+	id := c.Params("id")
+	m, err := h.service.GetMetrics(id)
+	if err != nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "not found"})
+	}
+	return c.JSON(m)
+}
+
+func (h *Handler) list(c *fiber.Ctx) error {
+	page, _ := strconv.Atoi(c.Query("page", "1"))
+	limit, _ := strconv.Atoi(c.Query("limit", "20"))
+	res, err := h.service.List(page, limit)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+	return c.JSON(res)
+}

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -4,12 +4,15 @@ import (
 	"github.com/dorsium/dorsium-rpc-gateway/internal/config"
 	mininghttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/mining"
 	nfthttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/nft"
+	nodehttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/node"
 	wallethttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/wallet"
 	nftrepo "github.com/dorsium/dorsium-rpc-gateway/internal/repository/nft"
+	noderepo "github.com/dorsium/dorsium-rpc-gateway/internal/repository/node"
 	walletrepo "github.com/dorsium/dorsium-rpc-gateway/internal/repository/wallet"
 	"github.com/dorsium/dorsium-rpc-gateway/internal/service"
 	miningservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/mining"
 	nftservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/nft"
+	nodeservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/node"
 	walletservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/wallet"
 	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
 	"github.com/gofiber/fiber/v2"
@@ -46,6 +49,13 @@ func (s *Server) RegisterRoutes() {
 	nHandler := nfthttp.NewHandler(nSvc)
 	nftGroup := api.Group("/nft")
 	nHandler.RegisterRoutes(nftGroup)
+
+	// node routes
+	nodeRepo := noderepo.New()
+	nodeSvc := nodeservice.New(nodeRepo)
+	nodeHandler := nodehttp.NewHandler(nodeSvc)
+	nodeGroup := api.Group("/node")
+	nodeHandler.RegisterRoutes(nodeGroup)
 
 	// mining routes
 	mVerifier := miningservice.NewDummyVerifier()

--- a/internal/repository/node/node.go
+++ b/internal/repository/node/node.go
@@ -1,0 +1,82 @@
+package node
+
+import (
+	"errors"
+	"time"
+
+	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
+)
+
+// Repository abstracts node data storage.
+type Repository interface {
+	Get(id string) (*model.Node, error)
+	Update(n *model.Node) error
+	List() ([]model.Node, error)
+}
+
+type repo struct {
+	store map[string]model.Node
+}
+
+// ErrNotFound is returned when a node does not exist.
+var ErrNotFound = errors.New("node not found")
+
+// New returns an in-memory node repository with mock data.
+func New() Repository {
+	r := &repo{store: make(map[string]model.Node)}
+	now := time.Now()
+	r.store["node1"] = model.Node{
+		ID:       "node1",
+		Label:    "Gateway Node 1",
+		Identity: "node-one",
+		Location: "Earth",
+		Status: model.NodeStatus{
+			Health:    "healthy",
+			LastPing:  now,
+			SyncState: "synced",
+		},
+		Metrics: model.NodeMetrics{
+			Uptime:       99.9,
+			RequestCount: 1000,
+			AvgResponse:  0.2,
+		},
+	}
+	r.store["node2"] = model.Node{
+		ID:       "node2",
+		Label:    "Gateway Node 2",
+		Identity: "node-two",
+		Location: "Mars",
+		Status: model.NodeStatus{
+			Health:    "healthy",
+			LastPing:  now,
+			SyncState: "syncing",
+		},
+		Metrics: model.NodeMetrics{
+			Uptime:       95.1,
+			RequestCount: 800,
+			AvgResponse:  0.25,
+		},
+	}
+	return r
+}
+
+func (r *repo) Get(id string) (*model.Node, error) {
+	n, ok := r.store[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return &n, nil
+}
+
+func (r *repo) Update(n *model.Node) error {
+	r.store[n.ID] = *n
+	return nil
+}
+
+func (r *repo) List() ([]model.Node, error) {
+	res := make([]model.Node, 0, len(r.store))
+	for _, n := range r.store {
+		res = append(res, n)
+	}
+	return res, nil
+}

--- a/internal/service/node/node.go
+++ b/internal/service/node/node.go
@@ -1,0 +1,93 @@
+package node
+
+import (
+	"time"
+
+	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
+)
+
+// Repository defines persistence layer requirements.
+type Repository interface {
+	Get(id string) (*model.Node, error)
+	Update(n *model.Node) error
+	List() ([]model.Node, error)
+}
+
+// Service exposes node operations.
+type Service interface {
+	GetStatus(id string) (*model.NodeStatus, error)
+	Ping(p model.NodePing) error
+	GetProfile(id string) (*model.NodeProfile, error)
+	GetMetrics(id string) (*model.NodeMetrics, error)
+	List(page, limit int) (*model.NodeListResponse, error)
+}
+
+type service struct {
+	repo Repository
+}
+
+// New creates a node service.
+func New(repo Repository) Service {
+	return &service{repo: repo}
+}
+
+func (s *service) GetStatus(id string) (*model.NodeStatus, error) {
+	n, err := s.repo.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	return &n.Status, nil
+}
+
+func (s *service) Ping(p model.NodePing) error {
+	n, err := s.repo.Get(p.ID)
+	if err != nil {
+		return err
+	}
+	n.Status.Health = p.Health
+	n.Status.SyncState = p.SyncState
+	n.Status.LastPing = time.Now()
+	return s.repo.Update(n)
+}
+
+func (s *service) GetProfile(id string) (*model.NodeProfile, error) {
+	n, err := s.repo.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	return &model.NodeProfile{ID: n.ID, Identity: n.Identity, Location: n.Location}, nil
+}
+
+func (s *service) GetMetrics(id string) (*model.NodeMetrics, error) {
+	n, err := s.repo.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	return &n.Metrics, nil
+}
+
+func (s *service) List(page, limit int) (*model.NodeListResponse, error) {
+	nodes, err := s.repo.List()
+	if err != nil {
+		return nil, err
+	}
+	if page <= 0 {
+		page = 1
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	start := (page - 1) * limit
+	if start > len(nodes) {
+		return &model.NodeListResponse{Page: page, Limit: limit, Items: []model.NodeListItem{}}, nil
+	}
+	end := start + limit
+	if end > len(nodes) {
+		end = len(nodes)
+	}
+	items := make([]model.NodeListItem, 0, end-start)
+	for _, n := range nodes[start:end] {
+		items = append(items, model.NodeListItem{ID: n.ID, Label: n.Label})
+	}
+	return &model.NodeListResponse{Page: page, Limit: limit, Items: items}, nil
+}

--- a/pkg/model/node.go
+++ b/pkg/model/node.go
@@ -1,0 +1,54 @@
+package model
+
+import "time"
+
+// NodeStatus represents health information for a node.
+type NodeStatus struct {
+	Health    string    `json:"health"`
+	LastPing  time.Time `json:"lastPing"`
+	SyncState string    `json:"syncState"`
+}
+
+// NodeProfile contains identity and location metadata.
+type NodeProfile struct {
+	ID       string `json:"id"`
+	Identity string `json:"identity"`
+	Location string `json:"location"`
+}
+
+// NodeMetrics holds usage statistics for a node.
+type NodeMetrics struct {
+	Uptime       float64 `json:"uptime"`
+	RequestCount int     `json:"requestCount"`
+	AvgResponse  float64 `json:"avgResponse"`
+}
+
+// NodeListItem represents a node in list responses.
+type NodeListItem struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+}
+
+// NodeListResponse wraps paginated list responses.
+type NodeListResponse struct {
+	Page  int            `json:"page"`
+	Limit int            `json:"limit"`
+	Items []NodeListItem `json:"items"`
+}
+
+// NodePing is received when nodes send heartbeat information.
+type NodePing struct {
+	ID        string `json:"id"`
+	Health    string `json:"health"`
+	SyncState string `json:"syncState"`
+}
+
+// Node aggregates all node information.
+type Node struct {
+	ID       string      `json:"id"`
+	Label    string      `json:"label"`
+	Identity string      `json:"identity"`
+	Location string      `json:"location"`
+	Status   NodeStatus  `json:"status"`
+	Metrics  NodeMetrics `json:"metrics"`
+}


### PR DESCRIPTION
## Summary
- implement node models for status, profile, metrics and lists
- add in-memory node repository with mock data
- add node service with pagination support
- add HTTP handler for node endpoints
- wire node routes in server

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6884114a144c8323b6cd25002fb2c8ce