### PR TITLE
Add validator endpoints

### DIFF
--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -5,14 +5,17 @@ import (
 	mininghttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/mining"
 	nfthttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/nft"
 	nodehttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/node"
+	validatorhttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/validator"
 	wallethttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/wallet"
 	nftrepo "github.com/dorsium/dorsium-rpc-gateway/internal/repository/nft"
 	noderepo "github.com/dorsium/dorsium-rpc-gateway/internal/repository/node"
+	validatorrepo "github.com/dorsium/dorsium-rpc-gateway/internal/repository/validator"
 	walletrepo "github.com/dorsium/dorsium-rpc-gateway/internal/repository/wallet"
 	"github.com/dorsium/dorsium-rpc-gateway/internal/service"
 	miningservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/mining"
 	nftservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/nft"
 	nodeservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/node"
+	validatorservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/validator"
 	walletservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/wallet"
 	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
 	"github.com/gofiber/fiber/v2"
@@ -49,6 +52,13 @@ func (s *Server) RegisterRoutes() {
 	nHandler := nfthttp.NewHandler(nSvc)
 	nftGroup := api.Group("/nft")
 	nHandler.RegisterRoutes(nftGroup)
+
+	// validator routes
+	vRepo := validatorrepo.New()
+	vSvc := validatorservice.New(vRepo)
+	vHandler := validatorhttp.NewHandler(vSvc)
+	vGroup := api.Group("/validator")
+	vHandler.RegisterRoutes(vGroup)
 
 	// node routes
 	nodeRepo := noderepo.New()

--- a/internal/http/validator/handler.go
+++ b/internal/http/validator/handler.go
@@ -1,0 +1,67 @@
+package validator
+
+import (
+	"regexp"
+	"strconv"
+
+	validatorsvc "github.com/dorsium/dorsium-rpc-gateway/internal/service/validator"
+	"github.com/gofiber/fiber/v2"
+)
+
+// Handler provides validator HTTP handlers.
+type Handler struct {
+	service validatorsvc.Service
+}
+
+// NewHandler creates a validator handler.
+func NewHandler(svc validatorsvc.Service) *Handler { return &Handler{service: svc} }
+
+// RegisterRoutes registers validator routes.
+func (h *Handler) RegisterRoutes(r fiber.Router) {
+	r.Get("/list", h.list)
+	r.Get("/:address/status", h.status)
+	r.Get("/:address/profile", h.profile)
+}
+
+func (h *Handler) status(c *fiber.Ctx) error {
+	addr := c.Params("address")
+	if !isValidAddress(addr) {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid address"})
+	}
+	st, err := h.service.GetStatus(addr)
+	if err != nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "not found"})
+	}
+	return c.JSON(st)
+}
+
+func (h *Handler) profile(c *fiber.Ctx) error {
+	addr := c.Params("address")
+	if !isValidAddress(addr) {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid address"})
+	}
+	prof, err := h.service.GetProfile(addr)
+	if err != nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "not found"})
+	}
+	return c.JSON(prof)
+}
+
+func (h *Handler) list(c *fiber.Ctx) error {
+	page, _ := strconv.Atoi(c.Query("page", "1"))
+	limit, _ := strconv.Atoi(c.Query("limit", "20"))
+	res, err := h.service.List(page, limit)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+	return c.JSON(res)
+}
+
+var (
+	hexRegex    = regexp.MustCompile(`^(0x)?[0-9a-fA-F]{40}$`)
+	bech32Regex = regexp.MustCompile(`^[a-z0-9]{1,83}1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38}$`)
+)
+
+func isValidAddress(addr string) bool {
+	return hexRegex.MatchString(addr) || bech32Regex.MatchString(addr)
+}

--- a/internal/repository/validator/validator.go
+++ b/internal/repository/validator/validator.go
@@ -1,0 +1,60 @@
+package validator
+
+import (
+	"errors"
+	"time"
+
+	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
+)
+
+// Repository abstracts validator data storage.
+type Repository interface {
+	Get(address string) (*model.Validator, error)
+	List() ([]model.Validator, error)
+}
+
+type repo struct {
+	store map[string]model.Validator
+}
+
+// ErrNotFound is returned when a validator does not exist.
+var ErrNotFound = errors.New("validator not found")
+
+// New returns an in-memory validator repository with mock data.
+func New() Repository {
+	r := &repo{store: make(map[string]model.Validator)}
+	now := time.Now()
+	r.store["0xvalidator1"] = model.Validator{
+		Address:    "0xvalidator1",
+		Name:       "Validator One",
+		Bio:        "First validator",
+		JoinDate:   now.AddDate(-1, 0, 0),
+		Reputation: 80,
+		Status:     model.ValidatorStatus{Status: "active"},
+	}
+	r.store["0xvalidator2"] = model.Validator{
+		Address:    "0xvalidator2",
+		Name:       "Validator Two",
+		Bio:        "Second validator",
+		JoinDate:   now.AddDate(-2, 0, 0),
+		Reputation: 95,
+		Status:     model.ValidatorStatus{Status: "jailed"},
+	}
+	return r
+}
+
+func (r *repo) Get(address string) (*model.Validator, error) {
+	v, ok := r.store[address]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return &v, nil
+}
+
+func (r *repo) List() ([]model.Validator, error) {
+	res := make([]model.Validator, 0, len(r.store))
+	for _, v := range r.store {
+		res = append(res, v)
+	}
+	return res, nil
+}

--- a/internal/service/validator/validator.go
+++ b/internal/service/validator/validator.go
@@ -1,0 +1,72 @@
+package validator
+
+import (
+	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
+)
+
+// Repository describes persistence layer requirements.
+type Repository interface {
+	Get(address string) (*model.Validator, error)
+	List() ([]model.Validator, error)
+}
+
+// Service exposes validator operations.
+type Service interface {
+	GetStatus(address string) (*model.ValidatorStatus, error)
+	GetProfile(address string) (*model.ValidatorProfile, error)
+	List(page, limit int) (*model.ValidatorListResponse, error)
+}
+
+type service struct {
+	repo Repository
+}
+
+// New creates a validator service.
+func New(repo Repository) Service { return &service{repo: repo} }
+
+func (s *service) GetStatus(address string) (*model.ValidatorStatus, error) {
+	v, err := s.repo.Get(address)
+	if err != nil {
+		return nil, err
+	}
+	return &v.Status, nil
+}
+
+func (s *service) GetProfile(address string) (*model.ValidatorProfile, error) {
+	v, err := s.repo.Get(address)
+	if err != nil {
+		return nil, err
+	}
+	return &model.ValidatorProfile{
+		Address:    v.Address,
+		Bio:        v.Bio,
+		JoinDate:   v.JoinDate,
+		Reputation: v.Reputation,
+	}, nil
+}
+
+func (s *service) List(page, limit int) (*model.ValidatorListResponse, error) {
+	vals, err := s.repo.List()
+	if err != nil {
+		return nil, err
+	}
+	if page <= 0 {
+		page = 1
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	start := (page - 1) * limit
+	if start > len(vals) {
+		return &model.ValidatorListResponse{Page: page, Limit: limit, Items: []model.ValidatorListItem{}}, nil
+	}
+	end := start + limit
+	if end > len(vals) {
+		end = len(vals)
+	}
+	items := make([]model.ValidatorListItem, 0, end-start)
+	for _, v := range vals[start:end] {
+		items = append(items, model.ValidatorListItem{Address: v.Address, Name: v.Name})
+	}
+	return &model.ValidatorListResponse{Page: page, Limit: limit, Items: items}, nil
+}

--- a/pkg/model/validator.go
+++ b/pkg/model/validator.go
@@ -1,0 +1,39 @@
+package model
+
+import "time"
+
+// ValidatorStatus represents the state of a validator.
+type ValidatorStatus struct {
+	Status string `json:"status"`
+}
+
+// ValidatorProfile holds validator metadata.
+type ValidatorProfile struct {
+	Address    string    `json:"address"`
+	Bio        string    `json:"bio"`
+	JoinDate   time.Time `json:"joinDate"`
+	Reputation int       `json:"reputation"`
+}
+
+// ValidatorListItem represents a validator in list responses.
+type ValidatorListItem struct {
+	Address string `json:"address"`
+	Name    string `json:"name"`
+}
+
+// ValidatorListResponse wraps paginated validator lists.
+type ValidatorListResponse struct {
+	Page  int                 `json:"page"`
+	Limit int                 `json:"limit"`
+	Items []ValidatorListItem `json:"items"`
+}
+
+// Validator aggregates all validator information.
+type Validator struct {
+	Address    string          `json:"address"`
+	Name       string          `json:"name"`
+	Bio        string          `json:"bio"`
+	JoinDate   time.Time       `json:"joinDate"`
+	Reputation int             `json:"reputation"`
+	Status     ValidatorStatus `json:"status"`
+}


### PR DESCRIPTION
## Summary
- implement validator service, repository and model
- add HTTP handlers for validator status, profile and list
- register validator routes in the HTTP server

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6884133423048323a83de22972b2f714