### PR TITLE
Implement RPC proxy

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ type Config struct {
 	Address      string
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
+	NodeRPC      string
 }
 
 // New creates a Config with default values.
@@ -15,5 +16,6 @@ func New() *Config {
 		Address:      ":8080",
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
+		NodeRPC:      "http://localhost:26657",
 	}
 }

--- a/internal/http/proxy/handler.go
+++ b/internal/http/proxy/handler.go
@@ -1,0 +1,43 @@
+package proxy
+
+import (
+	svc "github.com/dorsium/dorsium-rpc-gateway/internal/service/proxy"
+	"github.com/gofiber/fiber/v2"
+)
+
+// Handler provides proxy HTTP handlers.
+type Handler struct {
+	service svc.Service
+}
+
+// NewHandler creates a proxy handler.
+func NewHandler(svc svc.Service) *Handler {
+	return &Handler{service: svc}
+}
+
+// RegisterRoutes registers proxy routes.
+func (h *Handler) RegisterRoutes(r fiber.Router) {
+	r.Post("/tx/send", h.sendTx)
+	r.Get("/*", h.proxyGet)
+}
+
+func (h *Handler) sendTx(c *fiber.Ctx) error {
+	data := c.Body()
+	if len(data) == 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "empty body"})
+	}
+	resp, err := h.service.SendTx(data)
+	if err != nil {
+		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": err.Error()})
+	}
+	return c.Send(resp)
+}
+
+func (h *Handler) proxyGet(c *fiber.Ctx) error {
+	path := c.Params("*")
+	resp, err := h.service.ProxyGet("/"+path, c.Context().QueryArgs().String())
+	if err != nil {
+		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": err.Error()})
+	}
+	return c.Send(resp)
+}

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -6,10 +6,12 @@ import (
 	mininghttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/mining"
 	nfthttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/nft"
 	nodehttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/node"
+	proxyhttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/proxy"
 	validatorhttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/validator"
 	wallethttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/wallet"
 	nftrepo "github.com/dorsium/dorsium-rpc-gateway/internal/repository/nft"
 	noderepo "github.com/dorsium/dorsium-rpc-gateway/internal/repository/node"
+	proxyrepo "github.com/dorsium/dorsium-rpc-gateway/internal/repository/proxy"
 	validatorrepo "github.com/dorsium/dorsium-rpc-gateway/internal/repository/validator"
 	walletrepo "github.com/dorsium/dorsium-rpc-gateway/internal/repository/wallet"
 	"github.com/dorsium/dorsium-rpc-gateway/internal/service"
@@ -17,6 +19,7 @@ import (
 	miningservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/mining"
 	nftservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/nft"
 	nodeservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/node"
+	proxyservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/proxy"
 	validatorservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/validator"
 	walletservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/wallet"
 	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
@@ -85,6 +88,13 @@ func (s *Server) RegisterRoutes() {
 	mHandler := mininghttp.NewHandler(mSvc)
 	miningGroup := api.Group("/mining")
 	mHandler.RegisterRoutes(miningGroup)
+
+	// proxy routes
+	pRepo := proxyrepo.New(s.cfg.NodeRPC)
+	pSvc := proxyservice.New(pRepo)
+	pHandler := proxyhttp.NewHandler(pSvc)
+	proxyGroup := api.Group("/proxy")
+	pHandler.RegisterRoutes(proxyGroup)
 
 	// Placeholders for future endpoints
 	for i := 0; i < 25; i++ {

--- a/internal/repository/proxy/proxy.go
+++ b/internal/repository/proxy/proxy.go
@@ -1,0 +1,74 @@
+package proxy
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Repository forwards RPC requests to a Dorsium node.
+type Repository interface {
+	ForwardGet(path string, query string) ([]byte, error)
+	SendTx(data []byte) ([]byte, error)
+}
+
+type repo struct {
+	baseURL string
+	client  *http.Client
+}
+
+// New creates a proxy repository.
+func New(baseURL string) Repository {
+	return &repo{
+		baseURL: baseURL,
+		client:  &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (r *repo) tryRequest(method, url string, body []byte) ([]byte, error) {
+	var resp *http.Response
+	var err error
+	for i := 0; i < 3; i++ {
+		var b io.Reader
+		if body != nil {
+			b = bytes.NewReader(body)
+		}
+		req, reqErr := http.NewRequest(method, url, b)
+		if reqErr != nil {
+			return nil, reqErr
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err = r.client.Do(req)
+		if err == nil {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	out, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("rpc error: %s", resp.Status)
+	}
+	return out, nil
+}
+
+func (r *repo) ForwardGet(path string, query string) ([]byte, error) {
+	url := r.baseURL + path
+	if query != "" {
+		url += "?" + query
+	}
+	return r.tryRequest(http.MethodGet, url, nil)
+}
+
+func (r *repo) SendTx(data []byte) ([]byte, error) {
+	url := r.baseURL + "/tx/send"
+	return r.tryRequest(http.MethodPost, url, data)
+}

--- a/internal/service/proxy/proxy.go
+++ b/internal/service/proxy/proxy.go
@@ -1,0 +1,30 @@
+package proxy
+
+// Repository abstracts the proxy repository layer.
+type Repository interface {
+	ForwardGet(path string, query string) ([]byte, error)
+	SendTx(data []byte) ([]byte, error)
+}
+
+// Service defines proxy operations.
+type Service interface {
+	ProxyGet(path string, query string) ([]byte, error)
+	SendTx(data []byte) ([]byte, error)
+}
+
+type service struct {
+	repo Repository
+}
+
+// New creates a proxy service.
+func New(repo Repository) Service {
+	return &service{repo: repo}
+}
+
+func (s *service) ProxyGet(path string, query string) ([]byte, error) {
+	return s.repo.ForwardGet(path, query)
+}
+
+func (s *service) SendTx(data []byte) ([]byte, error) {
+	return s.repo.SendTx(data)
+}


### PR DESCRIPTION
## Summary
- add `NodeRPC` URL to config
- implement proxy repository and service for forwarding RPC calls
- register `/proxy` routes with handlers
- allow POST `/proxy/tx/send` for transactions and GET passthrough

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688416d358888323baed3facc9c6a33f