### PR TITLE
Add admin endpoints

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	Version        string
 	Mode           string
 	DisableMetrics bool
+	AdminToken     string
 }
 
 // New creates a Config with default values.
@@ -25,12 +26,16 @@ func New() *Config {
 		NodeRPC:      "http://localhost:26657",
 		Version:      "dev",
 		Mode:         "production",
+		AdminToken:   "changeme",
 	}
 	if v := os.Getenv("APP_VERSION"); v != "" {
 		c.Version = v
 	}
 	if m := os.Getenv("APP_MODE"); m != "" {
 		c.Mode = m
+	}
+	if t := os.Getenv("ADMIN_TOKEN"); t != "" {
+		c.AdminToken = t
 	}
 	c.DisableMetrics = os.Getenv("DISABLE_METRICS") == "true"
 	return c

--- a/internal/http/admin/handler.go
+++ b/internal/http/admin/handler.go
@@ -1,0 +1,53 @@
+package admin
+
+import (
+	adminsvc "github.com/dorsium/dorsium-rpc-gateway/internal/service/admin"
+	"github.com/gofiber/fiber/v2"
+)
+
+// Handler provides admin HTTP handlers.
+type Handler struct {
+	service adminsvc.Service
+	token   string
+}
+
+// NewHandler creates an admin handler.
+func NewHandler(svc adminsvc.Service, token string) *Handler {
+	return &Handler{service: svc, token: token}
+}
+
+// RegisterRoutes registers admin routes.
+func (h *Handler) RegisterRoutes(r fiber.Router) {
+	r.Use(h.auth)
+	r.Post("/broadcast", h.broadcast)
+	r.Get("/logs", h.logs)
+}
+
+func (h *Handler) auth(c *fiber.Ctx) error {
+	key := c.Get("X-Admin-Token")
+	if key == "" {
+		key = c.Get("X-Admin-Key")
+	}
+	if key != h.token {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "unauthorized"})
+	}
+	return c.Next()
+}
+
+func (h *Handler) broadcast(c *fiber.Ctx) error {
+	var req struct {
+		Message string `json:"message"`
+	}
+	if err := c.BodyParser(&req); err != nil || req.Message == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "message required"})
+	}
+	if err := h.service.Broadcast(req.Message); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+	return c.JSON(fiber.Map{"success": true})
+}
+
+func (h *Handler) logs(c *fiber.Ctx) error {
+	logs := h.service.GetLogs()
+	return c.JSON(fiber.Map{"logs": logs})
+}

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/dorsium/dorsium-rpc-gateway/internal/config"
+	adminhttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/admin"
 	dapphttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/dapp"
 	mininghttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/mining"
 	nfthttp "github.com/dorsium/dorsium-rpc-gateway/internal/http/nft"
@@ -20,6 +21,7 @@ import (
 	validatorrepo "github.com/dorsium/dorsium-rpc-gateway/internal/repository/validator"
 	walletrepo "github.com/dorsium/dorsium-rpc-gateway/internal/repository/wallet"
 	"github.com/dorsium/dorsium-rpc-gateway/internal/service"
+	adminservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/admin"
 	dappservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/dapp"
 	miningservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/mining"
 	nftservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/nft"
@@ -115,6 +117,12 @@ func (s *Server) RegisterRoutes() {
 	pHandler := proxyhttp.NewHandler(pSvc)
 	proxyGroup := api.Group("/proxy")
 	pHandler.RegisterRoutes(proxyGroup)
+
+	// admin routes
+	aSvc := adminservice.New(nodeRepo, vRepo)
+	aHandler := adminhttp.NewHandler(aSvc, s.cfg.AdminToken)
+	adminGroup := s.app.Group("/admin")
+	aHandler.RegisterRoutes(adminGroup)
 
 	// Placeholders for future endpoints
 	for i := 0; i < 25; i++ {

--- a/internal/service/admin/admin.go
+++ b/internal/service/admin/admin.go
@@ -1,0 +1,68 @@
+package admin
+
+import (
+	"sync"
+
+	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
+)
+
+// NodeRepository defines listing capabilities for nodes.
+type NodeRepository interface {
+	List() ([]model.Node, error)
+}
+
+// ValidatorRepository defines listing capabilities for validators.
+type ValidatorRepository interface {
+	List() ([]model.Validator, error)
+}
+
+// Service exposes admin operations.
+type Service interface {
+	Broadcast(msg string) error
+	GetLogs() []string
+}
+
+type service struct {
+	nodes      NodeRepository
+	validators ValidatorRepository
+	mu         sync.Mutex
+	logs       []string
+}
+
+// New creates an admin service.
+func New(nRepo NodeRepository, vRepo ValidatorRepository) Service {
+	return &service{nodes: nRepo, validators: vRepo, logs: make([]string, 0)}
+}
+
+func (s *service) Broadcast(msg string) error {
+	nodes, err := s.nodes.List()
+	if err != nil {
+		return err
+	}
+	validators, err := s.validators.List()
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, n := range nodes {
+		s.logs = append(s.logs, "node "+n.ID+": "+msg)
+	}
+	for _, v := range validators {
+		s.logs = append(s.logs, "validator "+v.Address+": "+msg)
+	}
+	return nil
+}
+
+func (s *service) GetLogs() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.logs) <= 100 {
+		res := make([]string, len(s.logs))
+		copy(res, s.logs)
+		return res
+	}
+	res := make([]string, 100)
+	copy(res, s.logs[len(s.logs)-100:])
+	return res
+}


### PR DESCRIPTION
## Summary
- add admin service and handler
- secure admin routes with token authentication
- support broadcast and log retrieval endpoints


------
https://chatgpt.com/codex/tasks/task_e_688419ba73f08323b4424033624060ab