### PR TITLE
Add env configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ Run unit tests with:
 go test ./...
 ```
 
+## Configuration
+
+The server reads its configuration from environment variables. Useful options:
+
+- `ADDRESS` sets the HTTP bind address (default `:8080`).
+- `NODE_RPC` defines the node RPC endpoint (default `http://localhost:26657`).
+

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,12 @@ func New() *Config {
 		Mode:         "production",
 		AdminToken:   "changeme",
 	}
+	if addr := os.Getenv("ADDRESS"); addr != "" {
+		c.Address = addr
+	}
+	if rpc := os.Getenv("NODE_RPC"); rpc != "" {
+		c.NodeRPC = rpc
+	}
 	if v := os.Getenv("APP_VERSION"); v != "" {
 		c.Version = v
 	}


### PR DESCRIPTION
## Summary
- read ADDRESS and NODE_RPC from the environment
- explain these variables in the README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68841cb38fbc8323a8c940566f4af33b