### PR TITLE
Add locks to repository maps

### DIFF
--- a/internal/repository/nft/nft.go
+++ b/internal/repository/nft/nft.go
@@ -2,6 +2,7 @@ package nft
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
 )
@@ -13,6 +14,7 @@ type Repository interface {
 }
 
 type repo struct {
+	mu    sync.RWMutex
 	store map[string]model.NFTMetadata
 }
 
@@ -25,12 +27,16 @@ func New() Repository {
 }
 
 func (r *repo) Save(n model.NFTMetadata) error {
+	r.mu.Lock()
 	r.store[n.ID] = n
+	r.mu.Unlock()
 	return nil
 }
 
 func (r *repo) GetByID(id string) (*model.NFTMetadata, error) {
+	r.mu.RLock()
 	n, ok := r.store[id]
+	r.mu.RUnlock()
 	if !ok {
 		return nil, ErrNotFound
 	}

--- a/internal/repository/validator/validator.go
+++ b/internal/repository/validator/validator.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
@@ -14,6 +15,7 @@ type Repository interface {
 }
 
 type repo struct {
+	mu    sync.RWMutex
 	store map[string]model.Validator
 }
 
@@ -44,7 +46,9 @@ func New() Repository {
 }
 
 func (r *repo) Get(address string) (*model.Validator, error) {
+	r.mu.RLock()
 	v, ok := r.store[address]
+	r.mu.RUnlock()
 	if !ok {
 		return nil, ErrNotFound
 	}
@@ -52,9 +56,11 @@ func (r *repo) Get(address string) (*model.Validator, error) {
 }
 
 func (r *repo) List() ([]model.Validator, error) {
+	r.mu.RLock()
 	res := make([]model.Validator, 0, len(r.store))
 	for _, v := range r.store {
 		res = append(res, v)
 	}
+	r.mu.RUnlock()
 	return res, nil
 }


### PR DESCRIPTION
## Summary
- add RWMutex guards to node, nft and validator repos
- lock map access for concurrent safety

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68841db43b508323b600d6389d60aaaf