### PR TITLE
Refactor address validation helpers

### DIFF
--- a/internal/http/dapp/handler.go
+++ b/internal/http/dapp/handler.go
@@ -1,10 +1,9 @@
 package dapp
 
 import (
-	"regexp"
-
 	dappsvc "github.com/dorsium/dorsium-rpc-gateway/internal/service/dapp"
 	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
+	"github.com/dorsium/dorsium-rpc-gateway/pkg/utils"
 	"github.com/go-playground/validator/v10"
 	"github.com/gofiber/fiber/v2"
 )
@@ -58,7 +57,7 @@ func (h *Handler) verifyWallet(c *fiber.Ctx) error {
 
 func (h *Handler) permissions(c *fiber.Ctx) error {
 	addr := c.Params("address")
-	if !isValidAddress(addr) {
+	if !utils.IsValidAddress(addr) {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid address"})
 	}
 	p, err := h.service.GetPermissions(addr)
@@ -66,13 +65,4 @@ func (h *Handler) permissions(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 	}
 	return c.JSON(p)
-}
-
-var (
-	hexRegex    = regexp.MustCompile(`^(0x)?[0-9a-fA-F]{40}$`)
-	bech32Regex = regexp.MustCompile(`^[a-z0-9]{1,83}1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38}$`)
-)
-
-func isValidAddress(addr string) bool {
-	return hexRegex.MatchString(addr) || bech32Regex.MatchString(addr)
 }

--- a/internal/http/validator/handler.go
+++ b/internal/http/validator/handler.go
@@ -1,10 +1,10 @@
 package validator
 
 import (
-	"regexp"
 	"strconv"
 
 	validatorsvc "github.com/dorsium/dorsium-rpc-gateway/internal/service/validator"
+	"github.com/dorsium/dorsium-rpc-gateway/pkg/utils"
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -25,7 +25,7 @@ func (h *Handler) RegisterRoutes(r fiber.Router) {
 
 func (h *Handler) status(c *fiber.Ctx) error {
 	addr := c.Params("address")
-	if !isValidAddress(addr) {
+	if !utils.IsValidAddress(addr) {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid address"})
 	}
 	st, err := h.service.GetStatus(addr)
@@ -37,7 +37,7 @@ func (h *Handler) status(c *fiber.Ctx) error {
 
 func (h *Handler) profile(c *fiber.Ctx) error {
 	addr := c.Params("address")
-	if !isValidAddress(addr) {
+	if !utils.IsValidAddress(addr) {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid address"})
 	}
 	prof, err := h.service.GetProfile(addr)
@@ -55,13 +55,4 @@ func (h *Handler) list(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 	}
 	return c.JSON(res)
-}
-
-var (
-	hexRegex    = regexp.MustCompile(`^(0x)?[0-9a-fA-F]{40}$`)
-	bech32Regex = regexp.MustCompile(`^[a-z0-9]{1,83}1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38}$`)
-)
-
-func isValidAddress(addr string) bool {
-	return hexRegex.MatchString(addr) || bech32Regex.MatchString(addr)
 }

--- a/internal/http/wallet/handler.go
+++ b/internal/http/wallet/handler.go
@@ -1,9 +1,8 @@
 package wallet
 
 import (
-	"regexp"
-
 	"github.com/dorsium/dorsium-rpc-gateway/internal/service/wallet"
+	"github.com/dorsium/dorsium-rpc-gateway/pkg/utils"
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -26,7 +25,7 @@ func (h *Handler) RegisterRoutes(r fiber.Router) {
 
 func (h *Handler) getInfo(c *fiber.Ctx) error {
 	addr := c.Params("address")
-	if !isValidAddress(addr) {
+	if !utils.IsValidAddress(addr) {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid address"})
 	}
 	info, err := h.service.GetInfo(addr)
@@ -38,7 +37,7 @@ func (h *Handler) getInfo(c *fiber.Ctx) error {
 
 func (h *Handler) getTransactions(c *fiber.Ctx) error {
 	addr := c.Params("address")
-	if !isValidAddress(addr) {
+	if !utils.IsValidAddress(addr) {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid address"})
 	}
 	txs, err := h.service.GetTransactions(addr, 50)
@@ -50,7 +49,7 @@ func (h *Handler) getTransactions(c *fiber.Ctx) error {
 
 func (h *Handler) getNFTs(c *fiber.Ctx) error {
 	addr := c.Params("address")
-	if !isValidAddress(addr) {
+	if !utils.IsValidAddress(addr) {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid address"})
 	}
 	nfts, err := h.service.GetNFTs(addr)
@@ -58,13 +57,4 @@ func (h *Handler) getNFTs(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 	}
 	return c.JSON(nfts)
-}
-
-var (
-	hexRegex    = regexp.MustCompile(`^(0x)?[0-9a-fA-F]{40}$`)
-	bech32Regex = regexp.MustCompile(`^[a-z0-9]{1,83}1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38}$`)
-)
-
-func isValidAddress(addr string) bool {
-	return hexRegex.MatchString(addr) || bech32Regex.MatchString(addr)
 }

--- a/pkg/utils/address.go
+++ b/pkg/utils/address.go
@@ -1,0 +1,13 @@
+package utils
+
+import "regexp"
+
+var (
+	hexRegex    = regexp.MustCompile(`^(0x)?[0-9a-fA-F]{40}$`)
+	bech32Regex = regexp.MustCompile(`^[a-z0-9]{1,83}1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38}$`)
+)
+
+// IsValidAddress validates bech32 or hex formatted addresses.
+func IsValidAddress(addr string) bool {
+	return hexRegex.MatchString(addr) || bech32Regex.MatchString(addr)
+}

--- a/tests/utils_test.go
+++ b/tests/utils_test.go
@@ -12,3 +12,21 @@ func TestReverse(t *testing.T) {
 		t.Errorf("expected %s", expected)
 	}
 }
+
+func TestIsValidAddress(t *testing.T) {
+	valid := []string{
+		"0x1234567890abcdef1234567890abcdef12345678",
+		"cosmos1qqpcymswlj9teu9gf28elksg5926y4v5d9dx7a",
+	}
+	for _, addr := range valid {
+		if !utils.IsValidAddress(addr) {
+			t.Errorf("expected valid address: %s", addr)
+		}
+	}
+	invalid := []string{"", "0x123", "cosmos1invalid"}
+	for _, addr := range invalid {
+		if utils.IsValidAddress(addr) {
+			t.Errorf("expected invalid address: %s", addr)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- share `IsValidAddress` in `pkg/utils/address.go`
- use the shared helper in wallet, dapp, and validator handlers
- test address validation logic

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68841fb914cc8323b885d4ef34c4f59e