### PR TITLE
Enforce max limit on node and validator lists

### DIFF
--- a/internal/http/node/handler.go
+++ b/internal/http/node/handler.go
@@ -73,6 +73,9 @@ func (h *Handler) metrics(c *fiber.Ctx) error {
 func (h *Handler) list(c *fiber.Ctx) error {
 	page, _ := strconv.Atoi(c.Query("page", "1"))
 	limit, _ := strconv.Atoi(c.Query("limit", "20"))
+	if limit > nodesvc.MaxListLimit {
+		limit = nodesvc.MaxListLimit
+	}
 	res, err := h.service.List(page, limit)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})

--- a/internal/http/validator/handler.go
+++ b/internal/http/validator/handler.go
@@ -50,6 +50,9 @@ func (h *Handler) profile(c *fiber.Ctx) error {
 func (h *Handler) list(c *fiber.Ctx) error {
 	page, _ := strconv.Atoi(c.Query("page", "1"))
 	limit, _ := strconv.Atoi(c.Query("limit", "20"))
+	if limit > validatorsvc.MaxListLimit {
+		limit = validatorsvc.MaxListLimit
+	}
 	res, err := h.service.List(page, limit)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})

--- a/internal/service/node/node.go
+++ b/internal/service/node/node.go
@@ -6,6 +6,9 @@ import (
 	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
 )
 
+// MaxListLimit caps the maximum number of items returned by List.
+const MaxListLimit = 100
+
 // Repository defines persistence layer requirements.
 type Repository interface {
 	Get(id string) (*model.Node, error)
@@ -76,6 +79,8 @@ func (s *service) List(page, limit int) (*model.NodeListResponse, error) {
 	}
 	if limit <= 0 {
 		limit = 20
+	} else if limit > MaxListLimit {
+		limit = MaxListLimit
 	}
 	start := (page - 1) * limit
 	if start > len(nodes) {

--- a/internal/service/validator/validator.go
+++ b/internal/service/validator/validator.go
@@ -4,6 +4,9 @@ import (
 	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
 )
 
+// MaxListLimit caps the maximum number of items returned by List.
+const MaxListLimit = 100
+
 // Repository describes persistence layer requirements.
 type Repository interface {
 	Get(address string) (*model.Validator, error)
@@ -55,6 +58,8 @@ func (s *service) List(page, limit int) (*model.ValidatorListResponse, error) {
 	}
 	if limit <= 0 {
 		limit = 20
+	} else if limit > MaxListLimit {
+		limit = MaxListLimit
 	}
 	start := (page - 1) * limit
 	if start > len(vals) {

--- a/tests/node_service_test.go
+++ b/tests/node_service_test.go
@@ -1,0 +1,28 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	noderepo "github.com/dorsium/dorsium-rpc-gateway/internal/repository/node"
+	nodesvc "github.com/dorsium/dorsium-rpc-gateway/internal/service/node"
+	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
+)
+
+func TestNodeListLimitCap(t *testing.T) {
+	repo := noderepo.New()
+	for i := 3; i <= nodesvc.MaxListLimit+50; i++ {
+		repo.Update(&model.Node{ID: fmt.Sprintf("node%d", i), Label: fmt.Sprintf("Node %d", i)})
+	}
+	svc := nodesvc.New(repo)
+	res, err := svc.List(1, nodesvc.MaxListLimit+50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Items) != nodesvc.MaxListLimit {
+		t.Fatalf("expected %d items, got %d", nodesvc.MaxListLimit, len(res.Items))
+	}
+	if res.Limit != nodesvc.MaxListLimit {
+		t.Fatalf("expected limit %d, got %d", nodesvc.MaxListLimit, res.Limit)
+	}
+}

--- a/tests/validator_service_test.go
+++ b/tests/validator_service_test.go
@@ -1,0 +1,45 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	validatorsvc "github.com/dorsium/dorsium-rpc-gateway/internal/service/validator"
+	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
+)
+
+// fakeValidatorRepo implements validatorsvc.Repository for testing.
+type fakeValidatorRepo struct {
+	items []model.Validator
+}
+
+func (f *fakeValidatorRepo) Get(address string) (*model.Validator, error) {
+	for _, v := range f.items {
+		if v.Address == address {
+			return &v, nil
+		}
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+func (f *fakeValidatorRepo) List() ([]model.Validator, error) {
+	return f.items, nil
+}
+
+func TestValidatorListLimitCap(t *testing.T) {
+	repo := &fakeValidatorRepo{}
+	for i := 0; i < validatorsvc.MaxListLimit+50; i++ {
+		repo.items = append(repo.items, model.Validator{Address: fmt.Sprintf("addr%d", i), Name: fmt.Sprintf("Val %d", i)})
+	}
+	svc := validatorsvc.New(repo)
+	res, err := svc.List(1, validatorsvc.MaxListLimit+50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Items) != validatorsvc.MaxListLimit {
+		t.Fatalf("expected %d items, got %d", validatorsvc.MaxListLimit, len(res.Items))
+	}
+	if res.Limit != validatorsvc.MaxListLimit {
+		t.Fatalf("expected limit %d, got %d", validatorsvc.MaxListLimit, res.Limit)
+	}
+}


### PR DESCRIPTION
## Summary
- cap list results in node and validator services
- enforce cap in node and validator HTTP handlers
- add tests for limit capping

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6884bfb5ee1c8323bc904b54e05705d1