### PR TITLE
Add context-aware proxy requests

### DIFF
--- a/internal/http/proxy/handler.go
+++ b/internal/http/proxy/handler.go
@@ -26,7 +26,7 @@ func (h *Handler) sendTx(c *fiber.Ctx) error {
 	if len(data) == 0 {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "empty body"})
 	}
-	resp, err := h.service.SendTx(data)
+	resp, err := h.service.SendTx(c.UserContext(), data)
 	if err != nil {
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": err.Error()})
 	}
@@ -35,7 +35,7 @@ func (h *Handler) sendTx(c *fiber.Ctx) error {
 
 func (h *Handler) proxyGet(c *fiber.Ctx) error {
 	path := c.Params("*")
-	resp, err := h.service.ProxyGet("/"+path, c.Context().QueryArgs().String())
+	resp, err := h.service.ProxyGet(c.UserContext(), "/"+path, c.Context().QueryArgs().String())
 	if err != nil {
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": err.Error()})
 	}

--- a/internal/service/proxy/proxy.go
+++ b/internal/service/proxy/proxy.go
@@ -1,15 +1,17 @@
 package proxy
 
+import "context"
+
 // Repository abstracts the proxy repository layer.
 type Repository interface {
-	ForwardGet(path string, query string) ([]byte, error)
-	SendTx(data []byte) ([]byte, error)
+	ForwardGet(ctx context.Context, path string, query string) ([]byte, error)
+	SendTx(ctx context.Context, data []byte) ([]byte, error)
 }
 
 // Service defines proxy operations.
 type Service interface {
-	ProxyGet(path string, query string) ([]byte, error)
-	SendTx(data []byte) ([]byte, error)
+	ProxyGet(ctx context.Context, path string, query string) ([]byte, error)
+	SendTx(ctx context.Context, data []byte) ([]byte, error)
 }
 
 type service struct {
@@ -21,10 +23,10 @@ func New(repo Repository) Service {
 	return &service{repo: repo}
 }
 
-func (s *service) ProxyGet(path string, query string) ([]byte, error) {
-	return s.repo.ForwardGet(path, query)
+func (s *service) ProxyGet(ctx context.Context, path string, query string) ([]byte, error) {
+	return s.repo.ForwardGet(ctx, path, query)
 }
 
-func (s *service) SendTx(data []byte) ([]byte, error) {
-	return s.repo.SendTx(data)
+func (s *service) SendTx(ctx context.Context, data []byte) ([]byte, error) {
+	return s.repo.SendTx(ctx, data)
 }

--- a/tests/proxy_repo_test.go
+++ b/tests/proxy_repo_test.go
@@ -1,0 +1,34 @@
+package tests
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	proxyrepo "github.com/dorsium/dorsium-rpc-gateway/internal/repository/proxy"
+)
+
+func TestProxyRepository_ContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	repo := proxyrepo.New(srv.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	if _, err := repo.ForwardGet(ctx, "/", ""); err == nil {
+		t.Fatalf("expected context cancellation error")
+	}
+
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel2()
+	if _, err := repo.SendTx(ctx2, []byte(`{}`)); err == nil {
+		t.Fatalf("expected context cancellation error")
+	}
+}


### PR DESCRIPTION
## Summary
- allow passing contexts through proxy repository and service
- update HTTP handler to use request context
- add tests for request cancellation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6884c277ec548323bd94d683c31b2895