### PR TITLE
Enforce admin log retention limit

### DIFF
--- a/tests/admin_service_test.go
+++ b/tests/admin_service_test.go
@@ -1,0 +1,47 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	adminsvc "github.com/dorsium/dorsium-rpc-gateway/internal/service/admin"
+	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
+)
+
+type fakeNodeRepo struct{}
+
+func (f *fakeNodeRepo) List() ([]model.Node, error) {
+	return []model.Node{{ID: "n1"}}, nil
+}
+
+type fakeAdminValidatorRepo struct{}
+
+func (f *fakeAdminValidatorRepo) List() ([]model.Validator, error) {
+	return []model.Validator{{Address: "v1"}}, nil
+}
+
+func TestAdminBroadcastPrunesLogs(t *testing.T) {
+	nRepo := &fakeNodeRepo{}
+	vRepo := &fakeAdminValidatorRepo{}
+	svc := adminsvc.New(nRepo, vRepo)
+
+	iterations := adminsvc.MaxLogLength/2 + 10
+	for i := 0; i < iterations; i++ {
+		if err := svc.Broadcast(fmt.Sprintf("msg%d", i)); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	logs := svc.GetLogs()
+	if len(logs) != adminsvc.MaxLogLength {
+		t.Fatalf("expected %d logs, got %d", adminsvc.MaxLogLength, len(logs))
+	}
+	firstExpected := fmt.Sprintf("node n1: msg%d", iterations-adminsvc.MaxLogLength/2)
+	if logs[0] != firstExpected {
+		t.Fatalf("expected first log %q got %q", firstExpected, logs[0])
+	}
+	lastExpected := fmt.Sprintf("validator v1: msg%d", iterations-1)
+	if logs[len(logs)-1] != lastExpected {
+		t.Fatalf("expected last log %q got %q", lastExpected, logs[len(logs)-1])
+	}
+}


### PR DESCRIPTION
## Summary
- keep at most 100 admin log entries
- trim old entries in `Broadcast`
- add tests for log pruning

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6884c7a984d883238af63c692cad10bc