### PR TITLE
Improve metrics bookkeeping

### DIFF
--- a/tests/server_metrics_test.go
+++ b/tests/server_metrics_test.go
@@ -1,0 +1,48 @@
+package tests
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dorsium/dorsium-rpc-gateway/internal/config"
+	server "github.com/dorsium/dorsium-rpc-gateway/internal/http"
+	"github.com/dorsium/dorsium-rpc-gateway/internal/service"
+)
+
+func TestMetricsAggregatesUnknown(t *testing.T) {
+	cfg := config.New()
+	cfg.DisableMetrics = false
+	srv := server.NewServer(cfg, service.New())
+	srv.RegisterRoutes()
+
+	for i := 0; i < 10; i++ {
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/unknown%d", i), nil)
+		if _, err := srv.App().Test(req); err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/ping", nil)
+	if _, err := srv.App().Test(req); err != nil {
+		t.Fatalf("ping failed: %v", err)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	resp, err := srv.App().Test(req)
+	if err != nil {
+		t.Fatalf("metrics failed: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if len(srv.Calls()) != 3 {
+		t.Fatalf("expected 3 endpoints recorded, got %d", len(srv.Calls()))
+	}
+	if !strings.Contains(string(body), `endpoint_calls_total{endpoint="unknown"} 10`) {
+		t.Fatalf("unexpected metrics output: %s", string(body))
+	}
+}


### PR DESCRIPTION
## Summary
- cap endpoint call bookkeeping
- report call stats using registered route paths
- add test for metrics aggregation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6884c86c23848323b4359f66726ed72f