### PR TITLE
Implement paginated list queries

### DIFF
--- a/internal/service/admin/admin.go
+++ b/internal/service/admin/admin.go
@@ -11,12 +11,12 @@ const MaxLogLength = 100
 
 // NodeRepository defines listing capabilities for nodes.
 type NodeRepository interface {
-	List() ([]model.Node, error)
+	List(page, limit int) ([]model.Node, error)
 }
 
 // ValidatorRepository defines listing capabilities for validators.
 type ValidatorRepository interface {
-	List() ([]model.Validator, error)
+	List(page, limit int) ([]model.Validator, error)
 }
 
 // Service exposes admin operations.
@@ -38,11 +38,11 @@ func New(nRepo NodeRepository, vRepo ValidatorRepository) Service {
 }
 
 func (s *service) Broadcast(msg string) error {
-	nodes, err := s.nodes.List()
+	nodes, err := s.nodes.List(1, 0)
 	if err != nil {
 		return err
 	}
-	validators, err := s.validators.List()
+	validators, err := s.validators.List(1, 0)
 	if err != nil {
 		return err
 	}

--- a/tests/admin_service_test.go
+++ b/tests/admin_service_test.go
@@ -10,13 +10,13 @@ import (
 
 type fakeNodeRepo struct{}
 
-func (f *fakeNodeRepo) List() ([]model.Node, error) {
+func (f *fakeNodeRepo) List(page, limit int) ([]model.Node, error) {
 	return []model.Node{{ID: "n1"}}, nil
 }
 
 type fakeAdminValidatorRepo struct{}
 
-func (f *fakeAdminValidatorRepo) List() ([]model.Validator, error) {
+func (f *fakeAdminValidatorRepo) List(page, limit int) ([]model.Validator, error) {
 	return []model.Validator{{Address: "v1"}}, nil
 }
 

--- a/tests/node_repo_test.go
+++ b/tests/node_repo_test.go
@@ -1,0 +1,25 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	noderepo "github.com/dorsium/dorsium-rpc-gateway/internal/repository/node"
+	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
+)
+
+func TestNodeRepositoryPagination(t *testing.T) {
+	repo := noderepo.New()
+	// add extra nodes
+	for i := 3; i <= 12; i++ {
+		repo.Update(&model.Node{ID: fmt.Sprintf("node%d", i), Label: fmt.Sprintf("Node %d", i)})
+	}
+
+	nodes, err := repo.List(2, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(nodes) != 5 {
+		t.Fatalf("expected 5 nodes, got %d", len(nodes))
+	}
+}

--- a/tests/validator_repo_test.go
+++ b/tests/validator_repo_test.go
@@ -1,0 +1,27 @@
+package tests
+
+import (
+	"testing"
+
+	validatorrepo "github.com/dorsium/dorsium-rpc-gateway/internal/repository/validator"
+)
+
+func TestValidatorRepositoryPagination(t *testing.T) {
+	repo := validatorrepo.New()
+
+	vals, err := repo.List(1, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vals) != 1 {
+		t.Fatalf("expected 1 validator, got %d", len(vals))
+	}
+
+	vals, err = repo.List(3, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vals) != 0 {
+		t.Fatalf("expected 0 validators, got %d", len(vals))
+	}
+}

--- a/tests/validator_service_test.go
+++ b/tests/validator_service_test.go
@@ -22,8 +22,22 @@ func (f *fakeValidatorRepo) Get(address string) (*model.Validator, error) {
 	return nil, fmt.Errorf("not found")
 }
 
-func (f *fakeValidatorRepo) List() ([]model.Validator, error) {
-	return f.items, nil
+func (f *fakeValidatorRepo) List(page, limit int) ([]model.Validator, error) {
+	if page <= 0 {
+		page = 1
+	}
+	if limit <= 0 {
+		limit = len(f.items)
+	}
+	start := (page - 1) * limit
+	if start >= len(f.items) {
+		return []model.Validator{}, nil
+	}
+	end := start + limit
+	if end > len(f.items) {
+		end = len(f.items)
+	}
+	return f.items[start:end], nil
 }
 
 func TestValidatorListLimitCap(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `page` and `limit` params to node and validator repositories
- update services and admin logic to call paginated repositories
- add tests verifying repository pagination

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6884d01e69f08323811327a7ef0ad899