### PR TITLE
Add recover middleware to server

### DIFF
--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -31,6 +31,7 @@ import (
 	walletservice "github.com/dorsium/dorsium-rpc-gateway/internal/service/wallet"
 	"github.com/dorsium/dorsium-rpc-gateway/pkg/model"
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/recover"
 	"github.com/shirou/gopsutil/v3/cpu"
 )
 
@@ -50,6 +51,7 @@ type Server struct {
 func NewServer(cfg *config.Config, svc service.Service) *Server {
 	app := fiber.New()
 	s := &Server{cfg: cfg, app: app, service: svc, start: time.Now(), calls: make(map[string]int)}
+	app.Use(recover.New())
 	app.Use(func(c *fiber.Ctx) error {
 		err := c.Next()
 		route := c.Route()


### PR DESCRIPTION
## Summary
- register Fiber recover middleware when constructing the server

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6884d75bad2883239bcef7f8d30539f4