### PR TITLE
Add admin token validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The server reads its configuration from environment variables:
 - `NODE_RPC` defines the node RPC endpoint (default `http://localhost:26657`).
 - `APP_VERSION` overrides the build version string (default `dev`).
 - `APP_MODE` sets the running mode (default `production`).
-- `ADMIN_TOKEN` configures the admin authentication token (default `changeme`).
+- `ADMIN_TOKEN` sets the admin authentication token (**required**).
 - `DISABLE_METRICS` turns off Prometheus metrics when set to `true`.
 - `MAX_RESPONSE_SIZE` limits the allowed response size in bytes (default `1048576`).
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,7 +9,10 @@ import (
 )
 
 func main() {
-	cfg := config.New()
+	cfg, err := config.New()
+	if err != nil {
+		log.Fatal(err)
+	}
 	svc := service.New()
 	srv := http.NewServer(cfg, svc)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"strconv"
 	"time"
@@ -20,7 +21,7 @@ type Config struct {
 }
 
 // New creates a Config with default values.
-func New() *Config {
+func New() (*Config, error) {
 	c := &Config{
 		Address:         ":8080",
 		ReadTimeout:     5 * time.Second,
@@ -28,7 +29,6 @@ func New() *Config {
 		NodeRPC:         "http://localhost:26657",
 		Version:         "dev",
 		Mode:            "production",
-		AdminToken:      "changeme",
 		MaxResponseSize: 1 << 20,
 	}
 	if addr := os.Getenv("ADDRESS"); addr != "" {
@@ -45,6 +45,8 @@ func New() *Config {
 	}
 	if t := os.Getenv("ADMIN_TOKEN"); t != "" {
 		c.AdminToken = t
+	} else {
+		return nil, errors.New("ADMIN_TOKEN is required")
 	}
 	if sz := os.Getenv("MAX_RESPONSE_SIZE"); sz != "" {
 		if v, err := strconv.ParseInt(sz, 10, 64); err == nil {
@@ -52,5 +54,5 @@ func New() *Config {
 		}
 	}
 	c.DisableMetrics = os.Getenv("DISABLE_METRICS") == "true"
-	return c
+	return c, nil
 }

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -1,0 +1,14 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/dorsium/dorsium-rpc-gateway/internal/config"
+)
+
+func TestConfigNewFailsWithoutAdminToken(t *testing.T) {
+	t.Setenv("ADMIN_TOKEN", "")
+	if _, err := config.New(); err == nil {
+		t.Fatal("expected error when ADMIN_TOKEN is missing")
+	}
+}

--- a/tests/server_metrics_test.go
+++ b/tests/server_metrics_test.go
@@ -14,7 +14,11 @@ import (
 )
 
 func TestMetricsAggregatesUnknown(t *testing.T) {
-	cfg := config.New()
+	t.Setenv("ADMIN_TOKEN", "secret")
+	cfg, err := config.New()
+	if err != nil {
+		t.Fatalf("config.New failed: %v", err)
+	}
 	cfg.DisableMetrics = false
 	srv := server.NewServer(cfg, service.New())
 	srv.RegisterRoutes()


### PR DESCRIPTION
## Summary
- ensure `ADMIN_TOKEN` is required in configuration
- handle configuration errors in `cmd/main.go`
- add unit test for missing admin token

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6884d823332c8323b7e1b9a68d841abc